### PR TITLE
Fix dark mode background colors

### DIFF
--- a/Sources/PrefabAppUI/Navigation/AppPagesView.swift
+++ b/Sources/PrefabAppUI/Navigation/AppPagesView.swift
@@ -59,6 +59,7 @@ public struct AppPagesView: View {
                 )
             }
         }
+        .background(AppColor.background.color)
         .environmentObject(EnvironmentValueContainer(value: analytics))
         .environmentObject(EnvironmentValueContainer(value: appService))
         .environmentObject(EnvironmentValueContainer(value: iconAssetBundle))

--- a/Sources/PrefabAppUI/Navigation/PageView.swift
+++ b/Sources/PrefabAppUI/Navigation/PageView.swift
@@ -23,6 +23,7 @@ struct PageView: View {
                 UnknownPageTypeView()
             }
         }
+        .background(AppColor.background.color)
         .environmentObject(EnvironmentValueContainer(value: pageContext))
     }
 }


### PR DESCRIPTION
Set `AppPagesView` and `PageView` backgrounds to `AppColor.background.color`.