### PR TITLE
fix: Missing AnalyticsProtocol environment object

### DIFF
--- a/Sources/PrefabAppAccessControl/AccessControl/AccessControlledView.swift
+++ b/Sources/PrefabAppAccessControl/AccessControl/AccessControlledView.swift
@@ -55,9 +55,10 @@ public struct AccessControlledView<UserSession, Content: View>: View {
                     userSessionInitializer: userSessionInitializer,
                     content: content
                 )
-                .environmentObject(EnvironmentValueContainer(value: analytics))
             }
-        }.task {
+        }
+        .environmentObject(EnvironmentValueContainer(value: analytics))
+        .task {
             for await authEvent in authClient.eventStream {
                 switch authEvent {
                 case .loggedIn:


### PR DESCRIPTION
Make sure `AnalyticsProtocol` is available in the environment for `LoginFlow`.