### PR TITLE
fix: Load page owner profile in `ProfileView`

### DIFF
--- a/Sources/PrefabAppCore/APIClient/APIOperation.swift
+++ b/Sources/PrefabAppCore/APIClient/APIOperation.swift
@@ -4,6 +4,8 @@ import Foundation
 public enum APIOperation: String {
     /// Returns an app spec.
     case appSpec
+    /// Returns a user profile given a user ID.
+    case userProfile
     /// Returns the current user's profile.
     case currentUserProfile
     /// Creates a new profile for the current user.

--- a/Sources/PrefabAppCore/Model/AppModel.swift
+++ b/Sources/PrefabAppCore/Model/AppModel.swift
@@ -30,6 +30,12 @@ final class AppModel: AppModelProtocol {
         }
     }
 
+    func userProfile(userID: String) async throws -> UserProfileSubject? {
+        try await objectStore.performWithinTransactionAsync { proxy in
+            proxy.value(forID: userID)
+        }
+    }
+
     @discardableResult
     func upsertProfile(inResponse response: APIResponse<UserProfileDTO>) throws -> UserProfileSubject {
         try mergeObjects(inResponse: response)

--- a/Sources/PrefabAppCore/Model/AppModelProtocol.swift
+++ b/Sources/PrefabAppCore/Model/AppModelProtocol.swift
@@ -4,6 +4,10 @@ import PrefabAppCoreInterface
 
 /// The top-level interface to an app's Model layer.
 protocol AppModelProtocol {
+    /// Returns a user profile given a user ID.
+    /// - Parameter userID: A user ID.
+    func userProfile(userID: String) async throws -> UserProfileSubject?
+
     /// Inserts or updates a user profile object to the store.
     /// - Parameter response: The API response containing the user profile to insert or update.
     /// - Returns: A `CurrentValueSubject` containing the inserted or updated user profile object.

--- a/Sources/PrefabAppCore/Service/UserProfileService.swift
+++ b/Sources/PrefabAppCore/Service/UserProfileService.swift
@@ -18,26 +18,42 @@ class UserProfileService: UserProfileServiceProtocol {
         self.appModel = appModel
     }
 
+    func userProfile(userID: String) async throws -> UserProfileSubject {
+        struct Params: Encodable {
+            let userID: String
+        }
+        if let existingProfile = try await appModel.userProfile(userID: userID) {
+            return existingProfile
+        } else {
+            let response: APIResponse<UserProfileDTO> = try await apiClient
+                .perform(
+                    operation: APIOperation.userProfile,
+                    params: Params(userID: userID)
+                )
+            return try appModel.upsertProfile(inResponse: response)
+        }
+    }
+
     func updateUsername(_ username: String) async throws {
-        struct UpdateUsernameParams: Encodable {
+        struct Params: Encodable {
             let username: String
         }
         let response: APIResponse<UserProfileDTO> = try await apiClient
             .perform(
                 operation: APIOperation.userProfileUpdate,
-                params: UpdateUsernameParams(username: username)
+                params: Params(username: username)
             )
         try appModel.upsertProfile(inResponse: response)
     }
 
     func updateDisplayName(_ displayName: String) async throws {
-        struct UpdateDisplayNameParams: Encodable {
+        struct Params: Encodable {
             let displayName: String
         }
         let response: APIResponse<UserProfileDTO> = try await apiClient
             .perform(
                 operation: APIOperation.userProfileUpdate,
-                params: UpdateDisplayNameParams(displayName: displayName)
+                params: Params(displayName: displayName)
             )
         try appModel.upsertProfile(inResponse: response)
     }

--- a/Sources/PrefabAppCoreInterface/Protocols/UserProfileServiceProtocol.swift
+++ b/Sources/PrefabAppCoreInterface/Protocols/UserProfileServiceProtocol.swift
@@ -3,6 +3,10 @@ import UIKit
 
 /// A protocol for a service that coordinates user profile operations in an app.
 public protocol UserProfileServiceProtocol {
+    /// Returns a user profile given a user ID.
+    /// - Parameter userID: A user ID.
+    func userProfile(userID: String) async throws -> UserProfileSubject
+
     /// Updates the current user profile with the given username.
     /// - Parameter username: A username.
     func updateUsername(_ username: String) async throws

--- a/Sources/PrefabAppUI/Navigation/PageView.swift
+++ b/Sources/PrefabAppUI/Navigation/PageView.swift
@@ -3,8 +3,6 @@ import SwiftUI
 
 /// A view that displays the contents of a page.
 struct PageView: View {
-    @EnvironmentObject private var userSession: UserSession
-
     /// A page type.
     let pageType: PageType
     /// A page context object.
@@ -18,7 +16,7 @@ struct PageView: View {
             case .content:
                 SubpagesView(subpages: subpages)
             case .userProfile:
-                ProfileView(userProfileSubject: userSession.userProfileSubject, subpages: subpages)
+                ProfileView(subpages: subpages)
             case .unknown:
                 UnknownPageTypeView()
             }

--- a/Sources/PrefabAppUI/Navigation/SubpagesView.swift
+++ b/Sources/PrefabAppUI/Navigation/SubpagesView.swift
@@ -111,6 +111,7 @@ struct SubpagesView<Header: View>: View {
                                 alignment: .bottom
                             )
                     }
+                    .tint(AppColor.contentPrimary.color)
                 }
             }
             .padding(.horizontal, 24)

--- a/Sources/PrefabAppUI/Pages/Profile/ProfileView.swift
+++ b/Sources/PrefabAppUI/Pages/Profile/ProfileView.swift
@@ -3,19 +3,33 @@ import SwiftUI
 
 /// A user profile view.
 struct ProfileView: View {
-    /// A `UserProfileSubject` that contains a user profile.
-    let userProfileSubject: UserProfileSubject
+    @EnvironmentObject private var pageContext: EnvironmentValueContainer<PageContext>
+    @EnvironmentObject private var userProfileService: EnvironmentValueContainer<UserProfileServiceProtocol>
+
     /// Subpages to show in the content section of the page.
     let subpages: [SubpageSpec]
 
     var body: some View {
-        SubpagesView(
-            header: {
-                ProfileHeaderView(viewModel: ObservableSubject(subject: userProfileSubject))
-                    .padding(24)
-            },
-            subpages: subpages
-        )
-        .frame(maxHeight: .infinity)
+        DataLoadingView(
+            load: { () async throws -> UserProfileSubject in
+                guard let profileID = pageContext.value.objectID else {
+                    throw ProfileViewError.missingProfileID
+                }
+                return try await userProfileService.value.userProfile(userID: profileID)
+            }
+        ) { userProfileSubject in
+            SubpagesView(
+                header: {
+                    ProfileHeaderView(viewModel: ObservableSubject(subject: userProfileSubject))
+                        .padding(24)
+                },
+                subpages: subpages
+            )
+            .frame(maxHeight: .infinity)
+        }
     }
+}
+
+private enum ProfileViewError: Error {
+    case missingProfileID
 }

--- a/Tests/PrefabAppCoreTests/AppModelTests.swift
+++ b/Tests/PrefabAppCoreTests/AppModelTests.swift
@@ -5,6 +5,28 @@ import Combine
 import PrefabAppCoreInterface
 
 final class AppModelTests: XCTestCase {
+    func testUserProfile() async throws {
+        let store = AppObjectStore()
+        let model = AppModel(objectStore: store, currentUserID: "1")
+
+        let nilProfileSubject = try await model.userProfile(userID: "1")
+        XCTAssertNil(nilProfileSubject)
+
+        let profileDTO = UserProfileDTO(
+            id: "1",
+            username: "johndoe",
+            displayName: "John Doe",
+            avatarUrl: nil,
+            bio: nil,
+            insertedAt: Date()
+        )
+        _ = try model.upsertProfile(
+            inResponse: APIResponse(data: profileDTO, included: nil)
+        )
+        let userProfileSubject = try await model.userProfile(userID: "1")
+        XCTAssertNotNil(userProfileSubject)
+    }
+
     func testUpsertProfile() throws {
         let store = AppObjectStore()
         let model = AppModel(objectStore: store, currentUserID: "1")

--- a/Tests/PrefabAppCoreTests/TestUtilities/MockAppModel.swift
+++ b/Tests/PrefabAppCoreTests/TestUtilities/MockAppModel.swift
@@ -4,6 +4,14 @@ import Foundation
 import PrefabAppCoreInterface
 
 final class MockAppModel: AppModelProtocol {
+    private(set) var userProfileCalled = false
+    var userProfileRV: UserProfileSubject?
+    @discardableResult
+    func userProfile(userID: String) throws -> UserProfileSubject? {
+        userProfileCalled = true
+        return userProfileRV
+    }
+
     private(set) var upsertProfileCalled = false
     var upsertProfileRV: UserProfileSubject?
     @discardableResult

--- a/Tests/PrefabAppCoreTests/UserProfileServiceTests.swift
+++ b/Tests/PrefabAppCoreTests/UserProfileServiceTests.swift
@@ -22,6 +22,26 @@ final class UserProfileServiceTests: XCTestCase {
         super.tearDown()
     }
 
+    func testUserProfile_profileExistsInAppModel() async throws {
+        appModel.userProfileRV = TestData.profileSubject
+        _ = try await userProfileService.userProfile(userID: TestData.profileSubject.id)
+        XCTAssertFalse(apiClient.performCalled)
+        XCTAssertTrue(appModel.userProfileCalled)
+    }
+
+    func testUserProfile_profileDoesNotExistInAppModel() async throws {
+        apiClient.performRV = APIResponse(
+            data: TestData.profileDTO,
+            included: nil
+        )
+        appModel.userProfileRV = nil
+        appModel.upsertProfileRV = TestData.profileSubject
+        _ = try await userProfileService.userProfile(userID: TestData.profileSubject.id)
+        XCTAssertTrue(apiClient.performCalled)
+        XCTAssertEqual(apiClient.performParams?.0, APIOperation.userProfile)
+        XCTAssertTrue(appModel.upsertProfileCalled)
+    }
+
     func testUpdateUsername() async throws {
         apiClient.performRV = APIResponse(
             data: TestData.profileDTO,


### PR DESCRIPTION
`ProfileView` always shows the logged in user's profile. To fix, using the user ID in the page context to correctly load the page owner's profile instead.