### PR TITLE
fix: Item card more button bugs

### DIFF
--- a/Sources/PrefabAppUI/Components/Cards/ItemCardMoreMenu.swift
+++ b/Sources/PrefabAppUI/Components/Cards/ItemCardMoreMenu.swift
@@ -10,26 +10,30 @@ struct ItemCardMoreMenu: View {
     @State private var isPresented: Bool = false
 
     var body: some View {
-        Button {
-            isPresented = true
-        } label: {
-            Image(systemName: "ellipsis")
-                .font(.system(size: 16, weight: .medium))
-                .frame(width: 32, height: 32)
-        }
-        .confirmationDialog("Item Actions", isPresented: $isPresented, titleVisibility: .hidden, actions: {
-            ForEach(menuItems, id: \.action) { menuItem in
-                switch menuItem.action {
-                case .delete:
-                    Button(role: .destructive) {
-                        onMenuItemTap(menuItem.action)
-                    } label: {
-                        Label("Delete", systemImage: "trash")
-                    }
-                case .unknown:
-                    EmptyView()
-                }
+        if menuItems.isEmpty {
+            EmptyView()
+        } else {
+            Button {
+                isPresented = true
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 16, weight: .medium))
+                    .frame(width: 32, height: 32)
             }
-        })
+            .confirmationDialog("Item Actions", isPresented: $isPresented, titleVisibility: .hidden, actions: {
+                ForEach(menuItems, id: \.action) { menuItem in
+                    switch menuItem.action {
+                    case .delete:
+                        Button(role: .destructive) {
+                            onMenuItemTap(menuItem.action)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    case .unknown:
+                        EmptyView()
+                    }
+                }
+            })
+        }
     }
 }

--- a/Sources/PrefabAppUI/Components/Cards/ItemCardMoreMenu.swift
+++ b/Sources/PrefabAppUI/Components/Cards/ItemCardMoreMenu.swift
@@ -7,8 +7,17 @@ struct ItemCardMoreMenu: View {
     /// A closure that is called when a menu item is tapped.
     let onMenuItemTap: (ItemCardMenuItem.Action) -> Void
 
+    @State private var isPresented: Bool = false
+
     var body: some View {
-        Menu {
+        Button {
+            isPresented = true
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 16, weight: .medium))
+                .frame(width: 32, height: 32)
+        }
+        .confirmationDialog("Item Actions", isPresented: $isPresented, titleVisibility: .hidden, actions: {
             ForEach(menuItems, id: \.action) { menuItem in
                 switch menuItem.action {
                 case .delete:
@@ -21,10 +30,6 @@ struct ItemCardMoreMenu: View {
                     EmptyView()
                 }
             }
-        } label: {
-            Image(systemName: "ellipsis")
-                .font(.system(size: 16, weight: .medium))
-                .frame(width: 32, height: 32)
-        }
+        })
     }
 }


### PR DESCRIPTION
A couple of minor bug fixes:
1. Use a confirmation dialog instead of a context menu to present item card actions. This avoids a `Menu` bug that causes the context menu to not appear on more button tap.
2. Hide the more button when there aren't any actions available.